### PR TITLE
modifications for ITK4 compatibility

### DIFF
--- a/itkCountNeighborsImageFilter.h
+++ b/itkCountNeighborsImageFilter.h
@@ -155,7 +155,7 @@ public:
    * in order to inform the pipeline execution model.
    *
    * \sa ImageToImageFilter::GenerateInputRequestedRegion() */
-  virtual void GenerateInputRequestedRegion() throw(InvalidRequestedRegionError);
+  virtual void GenerateInputRequestedRegion();
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */

--- a/itkCountNeighborsImageFilter.h
+++ b/itkCountNeighborsImageFilter.h
@@ -188,7 +188,7 @@ protected:
    * \sa ImageToImageFilter::ThreadedGenerateData(),
    *     ImageToImageFilter::GenerateData() */
   void ThreadedGenerateData(const OutputImageRegionType& outputRegionForThread,
-                            int threadId );
+                            ThreadIdType threadId );
 
 private:
   CountNeighborsImageFilter(const Self&); //purposely not implemented

--- a/itkCountNeighborsImageFilter.txx
+++ b/itkCountNeighborsImageFilter.txx
@@ -50,7 +50,7 @@ CountNeighborsImageFilter<TInputImage, TOutputImage>
 template <class TInputImage, class TOutputImage>
 void 
 CountNeighborsImageFilter<TInputImage, TOutputImage>
-::GenerateInputRequestedRegion() throw (InvalidRequestedRegionError)
+::GenerateInputRequestedRegion()
 {
   // call the superclass' implementation of this method
   Superclass::GenerateInputRequestedRegion();

--- a/itkCountNeighborsImageFilter.txx
+++ b/itkCountNeighborsImageFilter.txx
@@ -101,7 +101,7 @@ template< class TInputImage, class TOutputImage>
 void
 CountNeighborsImageFilter< TInputImage, TOutputImage>
 ::ThreadedGenerateData(const OutputImageRegionType& outputRegionForThread,
-                       int threadId)
+                       ThreadIdType threadId)
 {
   
   ConstantBoundaryCondition<InputImageType> nbc;


### PR DESCRIPTION
Modifications such that the following error is avoided with ITK4:
"The signature of ThreadedGenerateData() has been changed in ITK v4 to use the new ThreadIdType.
CountNeighborsImageFilter::ThreadedGenerateData() might need to be updated to used it."
